### PR TITLE
Fix VLS var length, increase var lbl length

### DIFF
--- a/SpssLib/FileParser/Records/VariableRecord.cs
+++ b/SpssLib/FileParser/Records/VariableRecord.cs
@@ -59,9 +59,8 @@ namespace SpssLib.FileParser.Records
                 HasVariableLabel = !string.IsNullOrEmpty(value);
                 if (!HasVariableLabel) return;
 
-                // TODO it might support more than 120, may be 252 or 255
                 int length;
-                _labelRaw = Encoding.GetPaddedRounded(value, 4, out length, 120);
+                _labelRaw = Encoding.GetPaddedRounded(value, 4, out length, 252);
                 LabelLength = length;
             }
         }

--- a/SpssLib/FileParser/SavFileParser.cs
+++ b/SpssLib/FileParser/SavFileParser.cs
@@ -383,7 +383,15 @@ namespace SpssLib.FileParser
             variable.Type = variableRecord.Type == 0 ? DataType.Numeric : DataType.Text;
             if (variable.Type == DataType.Text)
             {
-                variable.TextWidth = length;
+                int longLength;
+                if (metaData.VeryLongStringsDictionary.TryGetValue(variableRecord.Name, out longLength))
+                {
+                    variable.TextWidth = longLength;
+                }
+                else
+                {
+                    variable.TextWidth = length;
+                }
             }
 
             // TODO: There can be one value label for multiple varaibles, we might want to only cerate one and reference it from all variables


### PR DESCRIPTION
Fix issue with read variables reporting wrong lenght (255), instead of
the VeryLongString record declared size. The data read was not affected
by this
upgraded the max lenght for variable labels from 120 to 252
